### PR TITLE
Add pip cache purge to Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,8 @@ FROM python:latest
 
 RUN git clone https://github.com/vale46n1/immich_duplicate_finder.git && \
 cd immich_duplicate_finder && \
-pip install -r requirements.txt
+pip install -r requirements.txt && \
+pip cache purge
 
 WORKDIR /immich_duplicate_finder
 EXPOSE 8501


### PR DESCRIPTION
Low hanging fruit to reduce container size, e.g. at my build from 9.15GB to 6.34GB.

If interested, further improvements would be easily possible, e.g.:
- Non Root container (i guess there is no need to run as root from your side, right?)
- Dockerfile for CPU only systems
- In case #23 would be implemented, add default volume to folder for config
- Add default volume to folder for ~/.cache/torch/ to not need to reload it each time new container spawns