### PR TITLE
Fix convert RGBA to RGB image before Resnet Evaluation in imageDuplicate.py

### DIFF
--- a/imageDuplicate.py
+++ b/imageDuplicate.py
@@ -7,6 +7,7 @@ import numpy as np
 import faiss
 from torchvision.models import resnet152, ResNet152_Weights
 from torchvision.transforms import Compose, Resize, ToTensor, Normalize
+from PIL import Image
 
 from api import getImage
 from utility import display_asset_column
@@ -20,7 +21,15 @@ os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
 # Load ResNet152 with pretrained weights
 model = resnet152(weights=ResNet152_Weights.DEFAULT)
 model.eval()  # Set model to evaluation mode
+
+def convert_image_to_rgb(image):
+    """Convert image to RGB if it's RGBA."""
+    if image.mode == 'RGBA':
+        return image.convert('RGB')
+    return image
+
 transform = Compose([
+    convert_image_to_rgb,
     Resize((224, 224)),  # Standard size for ImageNet-trained models
     ToTensor(),
     Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),


### PR DESCRIPTION
Possible fix for https://github.com/vale46n1/immich_duplicate_finder/issues/32

ResNet does seem to have a problem with RGBA encoded images. This might help by converting an image to RGB before duplicate evaluation.

(btw: first PR ever, sorry in advance if I missed anything)

edit: ran on half my assets so far and everything regarding duplicate preview, comparison and deletion seems to be in working order