### PR TITLE
Fix issue #32, converting non RGB images into RGB

### DIFF
--- a/imageDuplicate.py
+++ b/imageDuplicate.py
@@ -20,7 +20,17 @@ os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
 # Load ResNet152 with pretrained weights
 model = resnet152(weights=ResNet152_Weights.DEFAULT)
 model.eval()  # Set model to evaluation mode
+
+
+def convert_image_to_rgb(image):
+    """Convert image to RGB if it's RGBA."""
+    if image.mode != 'RGB':
+        return image.convert('RGB')
+    return image
+
+
 transform = Compose([
+    convert_image_to_rgb,
     Resize((224, 224)),  # Standard size for ImageNet-trained models
     ToTensor(),
     Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),


### PR DESCRIPTION
Non RGB images causes the following error :
"RuntimeError: The size of tensor a (4) must match the size of tensor b (3) at non-singleton dimension 0"

as mentioned in https://github.com/vale46n1/immich_duplicate_finder/issues/32

This fixes the issue.
Credits to @Deathproof76 / AI