### PR TITLE
build fails with python 3.13. Pinning to 3.12.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.12
 
 RUN git clone https://github.com/vale46n1/immich_duplicate_finder.git /immich_duplicate_finder && \
 cd /immich_duplicate_finder && \


### PR DESCRIPTION
Failed building with docker. Likely due to dependencies not working with Python 3.13 release. Got it working with Python 3.12.